### PR TITLE
Add git support to todo and reorder help

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,17 @@ const argv = require('yargs')
       default: false
     }
   }, init)
+  .command('add', `create a new todo in today's file`, (yargs) => {
+    return yargs.option('item', {
+      alias: 'i'
+    })
+  }, newTodo)
+  .command('list', `list all the todo's`, (yargs) => {
+  	return yargs.option('raw',{
+  	  alias: 'r',
+  	  default: false 		
+  	})
+  }, list)
   .command('get-folder', `get the folder for your todos`, () => {}, () => {
     console.log(chalk.blue(config.todoRoot));
   })
@@ -31,18 +42,7 @@ const argv = require('yargs')
       setConfigProp({ todoRoot: expandedDir });
     });
   })
-  .command('list', `list all the todo's`, (yargs) => {
-  	return yargs.option('raw',{
-  	  alias: 'r',
-  	  default: false 		
-  	})
-  }, list)
   .command('new-day', `create a new .md for today`, () => {}, newTodoMonth)
-  .command('add', `create a new todo in today's file`, (yargs) => {
-    return yargs.option('item', {
-      alias: 'i'
-    })
-  }, newTodo)
   .group('item', 'add:')
   .group('dir', 'set-folder:')
   .group(['dir', 'with-git'], 'init:')

--- a/init.js
+++ b/init.js
@@ -2,11 +2,12 @@ const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
 const tilde = require('tilde-expansion');
+const shell = require('shelljs');
 const appRootDir = require('app-root-dir').get();
 const setConfigProp = require('./setConfigProp');
 const newTodoMonth = require('./newTodoMonth');
 
-const init = function({ dir, withGit }){
+const init = function({ dir, withGit=false }){
   tilde(dir, (expandedDir) => {
     if (!fs.existsSync(expandedDir)) return console.log(chalk.red('Directory for workbook doesnt exist'));
     console.log(chalk.green(`Initializing new todo workbook in ${dir}`));
@@ -15,8 +16,15 @@ const init = function({ dir, withGit }){
 
     if (!fs.existsSync( todoRoot )) fs.mkdirSync( todoRoot );
     writeConfig( configPath, todoRoot );
-    setConfigProp({ todoRoot });
+    setConfigProp({ todoRoot, withGit });
     newTodoMonth( todoRoot );
+    if (withGit) {
+      console.log(chalk.blue('Initialising with git'));
+      shell.cd(expandedDir);
+      shell.exec('git init');
+      shell.exec('git add --all');
+      shell.exec('git commit -m "Initial Commit"');
+    }
   });
 };
 

--- a/list.js
+++ b/list.js
@@ -3,6 +3,7 @@ const path = require('path');
 const config = require('./loadConfig');
 const glob = require('glob');
 const chalk = require('chalk');
+const shell = require('shelljs');
 const inquirer = require('inquirer');
 const getAllTodosFromFileArray = require('./getAllTodosFromFileArray');
 const getAllTodoFiles = require('./getAllTodoFiles');
@@ -18,7 +19,15 @@ const toggleTodos = function(newList){
       return todoLine;
     });
     fs.writeFileSync(file, todo.join('\r\n'));
+    if (config.withGit) {
+      shell.cd(config.todoRoot);
+      shell.exec(`git add ${file}`);
+    }
   });
+  if (config.withGit) {
+    shell.cd(config.todoRoot);
+    shell.exec(`git commit -m "Updated todos"`);
+  }
 }
 
 const list = function({ raw }){

--- a/newTodo.js
+++ b/newTodo.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const tilde = require('tilde-expansion');
 const mkdirp = require('mkdirp');
+const shell = require('shelljs');
 const config = require('./loadConfig');
 const getAllTodosFromFileArray = require('./getAllTodosFromFileArray');
 
@@ -35,6 +36,11 @@ const addNewTodo = function(args){
     let newFile = todoFileAsArray.join("\r\n");
     fs.writeFileSync(todayTodo, newFile);
     console.log(chalk.green(`Added new todo to ${todayTodo}`));
+    if (config.withGit) {
+      shell.cd(expandedDir);
+      shell.exec(`git add ${todayTodo}`);
+      shell.exec(`git commit -m "Added now todo to ${todayTodo}"`);
+    }
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "preferGlobal": true,
-  "bin": { "todo": "index.js" },
+  "bin": {
+    "todo": "index.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -16,6 +18,7 @@
     "glob": "^7.1.1",
     "inquirer": "^3.0.6",
     "mkdirp": "^0.5.1",
+    "shelljs": "^0.7.7",
     "tilde-expansion": "^0.0.0",
     "yargs": "^8.0.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,7 +145,7 @@ get-stream@^2.2.0:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
 
-glob@^7.1.1:
+glob@^7.0.0, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -198,6 +198,10 @@ inquirer@^3.0.6:
     string-width "^2.0.0"
     strip-ansi "^3.0.0"
     through "^2.3.6"
+
+interpret@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -381,6 +385,10 @@ path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 path-type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
@@ -420,6 +428,12 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -427,6 +441,12 @@ require-directory@^2.1.1:
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+
+resolve@^1.1.6:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  dependencies:
+    path-parse "^1.0.5"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -452,6 +472,14 @@ rx@^4.1.0:
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+shelljs@^0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
This adds support for git in the todo so that all changes are committed. We will commit and new todo as well as the change of state of any todos. 